### PR TITLE
Change http to https links

### DIFF
--- a/site/defaultWebMapItemData.json
+++ b/site/defaultWebMapItemData.json
@@ -483,7 +483,7 @@
                                                 "width": 24,
                                                 "contentType": "image/png",
                                                 "type": "esriPMS",
-                                                "url": "http://AFMLOCOMPORT.ESRI.COM/images/Symbols/Basic/GreenStickpin.png"
+                                                "url": "https://AFMLOCOMPORT.ESRI.COM/images/Symbols/Basic/GreenStickpin.png"
                                             },
                                             "description": "",
                                             "value": "0",
@@ -497,7 +497,7 @@
                                                 "width": 24,
                                                 "contentType": "image/png",
                                                 "type": "esriPMS",
-                                                "url": "http://AFMLOCOMPORT.ESRI.COM/images/Symbols/Basic/GreenShinyPin.png"
+                                                "url": "https://AFMLOCOMPORT.ESRI.COM/images/Symbols/Basic/GreenShinyPin.png"
                                             },
                                             "value": "1",
                                             "label": "Pushpin"


### PR DESCRIPTION
Updated the icon URLs from http to https. We still need to update the
basemap URL, but it doesn't currently work with HTTPS.
